### PR TITLE
Enable and Mapped the AARCH64 in According to ARM64

### DIFF
--- a/mk/support/pkg/v8.sh
+++ b/mk/support/pkg/v8.sh
@@ -136,7 +136,7 @@ pkg_install () {
         i?86)    arch=ia32 ;;
         x86_64)  arch=x64 ;;
         arm64)   arch=arm64; arch_gypflags=$arm_gypflags ;;
-        aarch64) arch=aarch64; arch_gypflags=$arm_gypflags ;;
+        aarch64) arch=arm64; arch_gypflags=$arm_gypflags ;;
         arm*)    arch=arm; arch_gypflags=$arm_gypflags ;;
         s390x)   arch=s390x ;;
 	ppc64le*|powerpc*) arch=ppc64 ;;

--- a/src/arch/runtime/context_switching.cc
+++ b/src/arch/runtime/context_switching.cc
@@ -260,7 +260,7 @@ artificial_stack_t::artificial_stack_t(void (*initial_fun)(void), size_t _stack_
 #elif defined(__arm__)
     // This slot is used to store r12.
     const size_t min_frame = 1;
-#elif defined(__arm64__)
+#elif defined(__arm64__) || defined (__aarch64__)
     // The ARM64 ABI requires the stack pointer to always be 16-byte-aligned at
     // all registers.
     const size_t min_frame = 1;
@@ -457,7 +457,7 @@ void context_switch(artificial_stack_context_ref_t *current_context_out, artific
 }
 
 asm(
-#if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined (__s390x__) || defined (__powerpc64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined (__s390x__) || defined (__powerpc64__) || defined (__arm64__) || defined (__aarch64__)
 // We keep architecture-specific code interleaved in order to enforce commonality.
 #if defined(__x86_64__)
 #if defined(__LP64__) || defined(__LLP64__)


### PR DESCRIPTION
Hi,

Package Owner: Mohneesh Jha
PR change Details:

#Patch Details :  mk/support/pkg/v8.sh and src/arch/runtime/context_switching.cc have been modified :

 mk/support/pkg/v8.sh : Mapped aarch64 with arm64 architecture
 src/arch/runtime/context_switching.cc: Added aarm64 flag in the declaration on minframe initialisation and register defination 
#Testing Detail :
The testing is done locally 

#Reviewer Comment : < To be filled by Reviewer >

#PR Description :
Here is my commit message : Enable and Mapped the AARCH64 in According to ARM64

Body of PR :

 mk/support/pkg/v8.sh and src/arch/runtime/context_switching.cc have been modified :

 mk/support/pkg/v8.sh : Mapped aarch64 with arm64 architecture
 src/arch/runtime/context_switching.cc: Added aarm64 flag in the declaration on minframe initialisation and register defination 

Signed-off-by: odidev@puresoftware.com.

#Reviewer: Pruthvi Teja

Thanks,
Mohneesh Jha